### PR TITLE
Remove the version numbers altogether!

### DIFF
--- a/reference-bot/java/bot.json
+++ b/reference-bot/java/bot.json
@@ -3,6 +3,6 @@
 	"email": "john.doe@example.com",
 	"nickName": "James",
 	"botLocation": "/target",
-	"botFileName": "reference-bot-1.0-SNAPSHOT-jar-with-dependencies.jar",
+	"botFileName": "reference-bot-jar-with-dependencies.jar",
 	"botLanguage": "java"
 }

--- a/reference-bot/java/pom.xml
+++ b/reference-bot/java/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>reference-bot</artifactId>
     <version>1.1-SNAPSHOT</version>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/starter-bots/java/bot.json
+++ b/starter-bots/java/bot.json
@@ -3,6 +3,6 @@
 	"email": "john.doe@example.com",
 	"nickName": "James",
 	"botLocation": "/target",
-	"botFileName": "java-sample-bot-1.1-SNAPSHOT-jar-with-dependencies.jar",
+	"botFileName": "java-sample-bot-jar-with-dependencies.jar",
 	"botLanguage": "java"
 }

--- a/starter-bots/java/pom.xml
+++ b/starter-bots/java/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>java-sample-bot</artifactId>
     <version>1.1-SNAPSHOT</version>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/starter-pack/reference-bot/java/bot.json
+++ b/starter-pack/reference-bot/java/bot.json
@@ -3,6 +3,6 @@
 	"email": "john.doe@example.com",
 	"nickName": "James",
 	"botLocation": "/target",
-	"botFileName": "reference-bot-1.0-SNAPSHOT-jar-with-dependencies.jar",
+	"botFileName": "reference-bot-jar-with-dependencies.jar",
 	"botLanguage": "java"
 }

--- a/starter-pack/reference-bot/java/pom.xml
+++ b/starter-pack/reference-bot/java/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>reference-bot</artifactId>
     <version>1.1-SNAPSHOT</version>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/starter-pack/starter-bots/java/bot.json
+++ b/starter-pack/starter-bots/java/bot.json
@@ -3,6 +3,6 @@
 	"email": "john.doe@example.com",
 	"nickName": "James",
 	"botLocation": "/target",
-	"botFileName": "java-sample-bot-1.1-SNAPSHOT-jar-with-dependencies.jar",
+	"botFileName": "java-sample-bot-jar-with-dependencies.jar",
 	"botLanguage": "java"
 }

--- a/starter-pack/starter-bots/java/pom.xml
+++ b/starter-pack/starter-bots/java/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>java-sample-bot</artifactId>
     <version>1.1-SNAPSHOT</version>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Avoid the weird version number issues by having the output file name exclude the version number. I do this by forcing the "finalName" value in Maven. 