### PR TITLE
Bugfix/threading issue

### DIFF
--- a/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/game/GameRoundProcessor.java
+++ b/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/game/GameRoundProcessor.java
@@ -1,6 +1,6 @@
 package za.co.entelect.challenge.game.contracts.game;
 
-import za.co.entelect.challenge.game.contracts.command.Command;
+import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 
 import java.util.ArrayList;
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public interface GameRoundProcessor {
 
-    boolean processRound(GameMap gameMap, Map<GamePlayer, Command> commandsToProcess);
+    boolean processRound(GameMap gameMap, Map<GamePlayer, RawCommand> commandsToProcess);
 
     ArrayList<String> getErrorList();
 }

--- a/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/game/GameRoundProcessor.java
+++ b/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/game/GameRoundProcessor.java
@@ -1,14 +1,14 @@
 package za.co.entelect.challenge.game.contracts.game;
 
-import za.co.entelect.challenge.game.contracts.command.RawCommand;
+import za.co.entelect.challenge.game.contracts.command.Command;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 
 import java.util.ArrayList;
-import java.util.Hashtable;
+import java.util.Map;
 
 public interface GameRoundProcessor {
 
-    boolean processRound(GameMap gameMap, Hashtable<GamePlayer, RawCommand> commandsToProcess);
+    boolean processRound(GameMap gameMap, Map<GamePlayer, Command> commandsToProcess);
 
     ArrayList<String> getErrorList();
 }

--- a/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/player/Player.java
+++ b/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/player/Player.java
@@ -1,6 +1,6 @@
 package za.co.entelect.challenge.game.contracts.player;
 
-import za.co.entelect.challenge.game.contracts.command.Command;
+import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.game.GamePlayer;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 
@@ -47,7 +47,7 @@ public abstract class Player {
         return String.format("Player{name='%s'}", name);
     }
 
-    public abstract Command getPlayerCommand(GameMap gameMap);
+    public abstract RawCommand getPlayerCommand(GameMap gameMap);
 
     public abstract void gameEnded(GameMap gameMap);
 

--- a/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/player/Player.java
+++ b/game-engine-interface/src/main/java/za/co/entelect/challenge/game/contracts/player/Player.java
@@ -1,11 +1,8 @@
 package za.co.entelect.challenge.game.contracts.player;
 
 import za.co.entelect.challenge.game.contracts.command.Command;
-import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.game.GamePlayer;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
-
-import java.util.function.BiConsumer;
 
 /**
  * The base class for all players/test harnesses of the game to extend.
@@ -42,14 +39,6 @@ public abstract class Player {
         this.name = name;
     }
 
-    public void playerRegistered(GamePlayer gamePlayer) {
-        this.gamePlayer = gamePlayer;
-    }
-
-    public void publishCommand(RawCommand command) {
-        publishCommandHandler.accept(this, command);
-    }
-
     public void roundComplete(GameMap gameMap, int round) {
     }
 
@@ -58,11 +47,7 @@ public abstract class Player {
         return String.format("Player{name='%s'}", name);
     }
 
-    public BiConsumer<Player, RawCommand> publishCommandHandler;
-
-    public abstract void startGame(GameMap gameMap);
-
-    public abstract void newRoundStarted(GameMap gameMap);
+    public abstract Command getPlayerCommand(GameMap gameMap);
 
     public abstract void gameEnded(GameMap gameMap);
 

--- a/game-runner/src/main/java/za/co/entelect/challenge/engine/runner/GameEngineRunner.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/engine/runner/GameEngineRunner.java
@@ -6,6 +6,7 @@ import za.co.entelect.challenge.commands.DoNothingCommand;
 import za.co.entelect.challenge.core.renderers.TowerDefenseConsoleMapRenderer;
 import za.co.entelect.challenge.engine.exceptions.InvalidRunnerState;
 import za.co.entelect.challenge.game.contracts.command.Command;
+import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.game.GameEngine;
 import za.co.entelect.challenge.game.contracts.game.GameMapGenerator;
 import za.co.entelect.challenge.game.contracts.game.GamePlayer;
@@ -85,7 +86,7 @@ public class GameEngineRunner {
 
         boolean successfulRound = false;
         while (!successfulRound) {
-            Map<GamePlayer, Command> commands = getPlayerCommands();
+            Map<GamePlayer, RawCommand> commands = getPlayerCommands();
 
             successfulRound = roundProcessor.processRound(commands);
 
@@ -116,7 +117,7 @@ public class GameEngineRunner {
 
         startNewRound();
 
-        Map<GamePlayer, Command> commands = getPlayerCommands();
+        Map<GamePlayer, RawCommand> commands = getPlayerCommands();
 
         roundProcessor.processRound(commands);
 
@@ -130,19 +131,19 @@ public class GameEngineRunner {
      *
      * @return Map of player commands
      */
-    private Map<GamePlayer, Command> getPlayerCommands() {
-        Map<Player, Future<Command>> futures = new HashMap<>();
+    private Map<GamePlayer, RawCommand> getPlayerCommands() {
+        Map<Player, Future<RawCommand>> futures = new HashMap<>();
         for (final Player player : players) {
-            Future<Command> playerCommand = PLAYER_EXECUTOR.submit(() -> player.getPlayerCommand(gameMap));
+            Future<RawCommand> playerCommand = PLAYER_EXECUTOR.submit(() -> player.getPlayerCommand(gameMap));
             futures.put(player, playerCommand);
         }
-        Map<GamePlayer, Command> commands = new HashMap<>();
-        for (Map.Entry<Player, Future<Command>> entry : futures.entrySet()) {
+        Map<GamePlayer, RawCommand> commands = new HashMap<>();
+        for (Map.Entry<Player, Future<RawCommand>> entry : futures.entrySet()) {
             try {
                 //The get will block until the thread completes:
                 commands.put(entry.getKey().getGamePlayer(), entry.getValue().get());
             } catch (InterruptedException | ExecutionException ignored) {
-                commands.put(entry.getKey().getGamePlayer(), new DoNothingCommand());
+                commands.put(entry.getKey().getGamePlayer(), new RawCommand());
             }
         }
         return commands;

--- a/game-runner/src/main/java/za/co/entelect/challenge/engine/runner/RunnerRoundProcessor.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/engine/runner/RunnerRoundProcessor.java
@@ -2,17 +2,15 @@ package za.co.entelect.challenge.engine.runner;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import za.co.entelect.challenge.engine.exceptions.InvalidCommandException;
 import za.co.entelect.challenge.engine.exceptions.InvalidOperationException;
-import za.co.entelect.challenge.game.contracts.command.RawCommand;
+import za.co.entelect.challenge.game.contracts.command.Command;
 import za.co.entelect.challenge.game.contracts.game.GamePlayer;
 import za.co.entelect.challenge.game.contracts.game.GameRoundProcessor;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
-import za.co.entelect.challenge.game.contracts.player.Player;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Hashtable;
+import java.util.Map;
 
 public class RunnerRoundProcessor {
     private static final Logger log = LogManager.getLogger(RunnerRoundProcessor.class);
@@ -21,38 +19,24 @@ public class RunnerRoundProcessor {
     private GameRoundProcessor gameRoundProcessor;
 
     private boolean roundProcessed;
-    private Hashtable<GamePlayer, RawCommand> commandsToProcess;
 
     RunnerRoundProcessor(GameMap gameMap, GameRoundProcessor gameRoundProcessor) {
         this.gameMap = gameMap;
         this.gameRoundProcessor = gameRoundProcessor;
-
-        commandsToProcess = new Hashtable<>();
     }
 
-    boolean processRound() throws Exception {
+    boolean processRound(Map<GamePlayer, Command> commands) throws Exception {
         if (roundProcessed) {
             throw new InvalidOperationException("This round has already been processed!");
         }
 
-        boolean processed = gameRoundProcessor.processRound(gameMap, commandsToProcess);
+        boolean processed = gameRoundProcessor.processRound(gameMap, commands);
         ArrayList<String> errorList = gameRoundProcessor.getErrorList();
         //TODO: Remove later
         log.info("Error List: " + Arrays.toString(errorList.toArray()));
         roundProcessed = true;
 
         return processed;
-    }
-
-    void addPlayerCommand(Player player, RawCommand command) {
-        try {
-            if (commandsToProcess.containsKey(player.getGamePlayer()))
-                throw new InvalidCommandException("Player already has a command registered for this round, wait for the next round before sending a new command");
-
-            commandsToProcess.put(player.getGamePlayer(), command);
-        } catch (InvalidCommandException e) {
-            log.error(e.getStackTrace());
-        }
     }
 
     void resetBackToStart() {

--- a/game-runner/src/main/java/za/co/entelect/challenge/engine/runner/RunnerRoundProcessor.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/engine/runner/RunnerRoundProcessor.java
@@ -3,7 +3,7 @@ package za.co.entelect.challenge.engine.runner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import za.co.entelect.challenge.engine.exceptions.InvalidOperationException;
-import za.co.entelect.challenge.game.contracts.command.Command;
+import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.game.GamePlayer;
 import za.co.entelect.challenge.game.contracts.game.GameRoundProcessor;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
@@ -25,7 +25,7 @@ public class RunnerRoundProcessor {
         this.gameRoundProcessor = gameRoundProcessor;
     }
 
-    boolean processRound(Map<GamePlayer, Command> commands) throws Exception {
+    boolean processRound(Map<GamePlayer, RawCommand> commands) throws Exception {
         if (roundProcessed) {
             throw new InvalidOperationException("This round has already been processed!");
         }

--- a/game-runner/src/main/java/za/co/entelect/challenge/player/BotPlayer.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/player/BotPlayer.java
@@ -6,7 +6,6 @@ import za.co.entelect.challenge.botrunners.BotRunner;
 import za.co.entelect.challenge.core.renderers.TowerDefenseConsoleMapRenderer;
 import za.co.entelect.challenge.core.renderers.TowerDefenseJsonGameMapRenderer;
 import za.co.entelect.challenge.core.renderers.TowerDefenseTextMapRenderer;
-import za.co.entelect.challenge.game.contracts.command.Command;
 import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 import za.co.entelect.challenge.game.contracts.player.Player;
@@ -42,7 +41,7 @@ public class BotPlayer extends Player {
     }
 
     @Override
-    public Command getPlayerCommand(GameMap gameMap) {
+    public RawCommand getPlayerCommand(GameMap gameMap) {
         String playerSpecificJsonState = jsonRenderer.render(gameMap, getGamePlayer());
         String playerSpecificTextState = textRenderer.render(gameMap, getGamePlayer());
         String playerSpecificConsoleState = consoleRenderer.render(gameMap, getGamePlayer());

--- a/game-runner/src/main/java/za/co/entelect/challenge/player/BotPlayer.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/player/BotPlayer.java
@@ -6,7 +6,7 @@ import za.co.entelect.challenge.botrunners.BotRunner;
 import za.co.entelect.challenge.core.renderers.TowerDefenseConsoleMapRenderer;
 import za.co.entelect.challenge.core.renderers.TowerDefenseJsonGameMapRenderer;
 import za.co.entelect.challenge.core.renderers.TowerDefenseTextMapRenderer;
-import za.co.entelect.challenge.engine.runner.GameEngineRunner;
+import za.co.entelect.challenge.game.contracts.command.Command;
 import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 import za.co.entelect.challenge.game.contracts.player.Player;
@@ -42,12 +42,7 @@ public class BotPlayer extends Player {
     }
 
     @Override
-    public void startGame(GameMap gameMap) {
-        newRoundStarted(gameMap);
-    }
-
-    @Override
-    public void newRoundStarted(GameMap gameMap) {
+    public Command getPlayerCommand(GameMap gameMap) {
         String playerSpecificJsonState = jsonRenderer.render(gameMap, getGamePlayer());
         String playerSpecificTextState = textRenderer.render(gameMap, getGamePlayer());
         String playerSpecificConsoleState = consoleRenderer.render(gameMap, getGamePlayer());
@@ -81,8 +76,7 @@ public class BotPlayer extends Player {
             e.printStackTrace();
         }
 
-        RawCommand rawCommand = new RawCommand(botInput);
-        publishCommand(rawCommand);
+        return new RawCommand(botInput);
     }
 
     private void writeRoundStateData(String playerSpecificJsonState, String playerSpecificTextState,

--- a/game-runner/src/main/java/za/co/entelect/challenge/player/ConsolePlayer.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/player/ConsolePlayer.java
@@ -3,7 +3,7 @@ package za.co.entelect.challenge.player;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import za.co.entelect.challenge.core.renderers.TowerDefenseConsoleMapRenderer;
-import za.co.entelect.challenge.engine.runner.GameEngineRunner;
+import za.co.entelect.challenge.game.contracts.command.Command;
 import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 import za.co.entelect.challenge.game.contracts.player.Player;
@@ -26,12 +26,7 @@ public class ConsolePlayer extends Player {
     }
 
     @Override
-    public void startGame(GameMap gameMap) {
-        newRoundStarted(gameMap);
-    }
-
-    @Override
-    public void newRoundStarted(GameMap gameMap) {
+    public Command getPlayerCommand(GameMap gameMap) {
 
         String output = gameMapRenderer.render(gameMap, getGamePlayer());
         log.info(output);
@@ -41,8 +36,7 @@ public class ConsolePlayer extends Player {
 
         String consoleInput = scanner.nextLine();
 
-        RawCommand rawCommand = new RawCommand(consoleInput);
-        publishCommand(rawCommand);
+        return new RawCommand(consoleInput);
     }
 
     @Override

--- a/game-runner/src/main/java/za/co/entelect/challenge/player/ConsolePlayer.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/player/ConsolePlayer.java
@@ -3,7 +3,6 @@ package za.co.entelect.challenge.player;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import za.co.entelect.challenge.core.renderers.TowerDefenseConsoleMapRenderer;
-import za.co.entelect.challenge.game.contracts.command.Command;
 import za.co.entelect.challenge.game.contracts.command.RawCommand;
 import za.co.entelect.challenge.game.contracts.map.GameMap;
 import za.co.entelect.challenge.game.contracts.player.Player;
@@ -26,7 +25,7 @@ public class ConsolePlayer extends Player {
     }
 
     @Override
-    public Command getPlayerCommand(GameMap gameMap) {
+    public RawCommand getPlayerCommand(GameMap gameMap) {
 
         String output = gameMapRenderer.render(gameMap, getGamePlayer());
         log.info(output);


### PR DESCRIPTION
There is a small multithreading issue in the `GameEngineRunner` class. 
Around line 84 and 119, a new thread is created to handle the running of a new bot. 
I assume the intention is to allow multiple bots to run concurrently. 
However, roughly two lines later, the thread is joined to the current thread using the `.join` method. The net effect of this is that each bot will in effect run sequentially. The one bot will have to complete, before the next one is created in its own separate thread. 
In addition, each time a thread is needed, it is created as a new thread. In this PR, I have changed this to use a thread pool and so this should result in a slight performance improvement, since the threads will be reused. 
Note that I have also removed the player command listener structure, and replaced it with a simple method call to the player object itself (method named `getPlayerCommand`). This is to avoid potentially confusing threading issues in the callback methods. 