### PR TITLE
Fixed off by 1 error for construction time and tesla stats not displaying

### DIFF
--- a/game-engine/core/src/main/java/za/co/entelect/challenge/core/renderers/RendererHelper.java
+++ b/game-engine/core/src/main/java/za/co/entelect/challenge/core/renderers/RendererHelper.java
@@ -2,12 +2,9 @@ package za.co.entelect.challenge.core.renderers;
 
 import za.co.entelect.challenge.config.GameConfig;
 import za.co.entelect.challenge.core.entities.CellStateContainer;
-import za.co.entelect.challenge.entities.Cell;
 import za.co.entelect.challenge.entities.TowerDefenseGameMap;
 import za.co.entelect.challenge.enums.PlayerType;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.IntStream;
 
 public class RendererHelper {
@@ -39,20 +36,20 @@ public class RendererHelper {
 
         towerDefenseGameMap.getMissiles()
                 .forEach(p -> {
-                    outputMap[p.getY()][GameConfig.getMapWidth() - p.getX() - 1 ].missiles.add(p.getInvertedXInstance());
+                    outputMap[p.getY()][GameConfig.getMapWidth() - p.getX() - 1].missiles.add(p.getInvertedXInstance());
                 });
 
         return outputMap;
     }
 
-    private static CellStateContainer[][] generateEmptyBoard(){
+    private static CellStateContainer[][] generateEmptyBoard() {
         CellStateContainer[][] outputMap = new CellStateContainer[GameConfig.getMapHeight()][GameConfig.getMapWidth()];
 
         IntStream.range(0, GameConfig.getMapHeight())
                 .forEach(y -> {
                             IntStream.range(0, GameConfig.getMapWidth())
                                     .forEach(x -> {
-                                        PlayerType renderedPlayerType = (x >= GameConfig.getMapWidth()/2 ? PlayerType.B : PlayerType.A);
+                                        PlayerType renderedPlayerType = (x >= GameConfig.getMapWidth() / 2 ? PlayerType.B : PlayerType.A);
 
                                         outputMap[y][x] = new CellStateContainer(x, y, renderedPlayerType);
                                     });

--- a/game-engine/core/src/main/java/za/co/entelect/challenge/core/renderers/TowerDefenseJsonGameMapRenderer.java
+++ b/game-engine/core/src/main/java/za/co/entelect/challenge/core/renderers/TowerDefenseJsonGameMapRenderer.java
@@ -33,10 +33,7 @@ public class TowerDefenseJsonGameMapRenderer implements GameMapRenderer {
             } else {
                 container = new TowerDefenseJsonContainer(RendererHelper.renderPlayerB(towerDefenseGameMap), getPlayerDataForPlayer(player), towerDefenseGameMap.getCurrentRound(), towerDefenseGameMap.getTeslaTargetList());
             }
-            if (container == null) {
-                log.error("The container cannot be empty.");
-                return "";
-            }
+
             return gson.toJson(container);
         }
 

--- a/game-engine/domain/src/main/java/za/co/entelect/challenge/entities/Building.java
+++ b/game-engine/domain/src/main/java/za/co/entelect/challenge/entities/Building.java
@@ -107,6 +107,7 @@ public class Building extends Cell {
                 this.constructionScore,
                 this.energyGeneratedPerTurn,
                 this.maxRange,
+                this.energyPerShot,
                 this.buildingType);
 
         newBuilding.weaponCooldownTimeLeft = this.weaponCooldownTimeLeft;
@@ -141,7 +142,7 @@ public class Building extends Cell {
     }
 
     public int getConstructionTimeLeft() {
-        return constructionTimeLeft + 1; // construction happens on same round as placement
+        return constructionTimeLeft; // construction happens on same round as placement
     }
 
     public void decreaseConstructionTimeLeft() {
@@ -149,7 +150,7 @@ public class Building extends Cell {
     }
 
     public boolean isConstructed() {
-        return (getConstructionTimeLeft() <= 0);
+        return (getConstructionTimeLeft() <= -1);
     }
 
     public int getHealth() {

--- a/game-runner/game-config.properties
+++ b/game-runner/game-config.properties
@@ -10,7 +10,7 @@ game.config.energy-score-multiplier = 1
 game.config.deconstruction-refund-amount = 5
 game.config.max-do-nothings = 50
 
-#Basic Wall Config
+#DEFENSE Building Config
 game.config.defense.config.health = 20
 game.config.defense.config.construction-time-left = 3
 game.config.defense.config.price = 30
@@ -23,7 +23,7 @@ game.config.defense.config.construction-score = 10
 game.config.defense.config.energy-produced-per-turn = 0
 game.config.defense.config.max-range = 0
 
-#Basic Turret Config
+#ATTACK Building Config
 game.config.attack.config.health = 5
 game.config.attack.config.construction-time-left = 1
 game.config.attack.config.price = 30
@@ -37,7 +37,7 @@ game.config.attack.config.energy-produced-per-turn = 0
 game.config.attack.config.max-range = 0
 
 
-#Basic Energy Generator Config
+#ENERGY Building Config
 game.config.energy.config.health = 5
 game.config.energy.config.construction-time-left = 1
 game.config.energy.config.price = 20
@@ -50,7 +50,7 @@ game.config.energy.config.construction-score = 3
 game.config.energy.config.energy-produced-per-turn = 3
 game.config.energy.config.max-range = 0
 
-#Tesla Tower Config
+#TESLA Building Config
 game.config.tesla.config.health = 5
 game.config.tesla.config.construction-time-left = 10
 game.config.tesla.config.price = 300

--- a/starter-pack/examples/example-state.json
+++ b/starter-pack/examples/example-state.json
@@ -14,47 +14,47 @@
     "buildingsStats": {
       "TESLA": {
         "health": 5,
-        "constructionTime": 11,
+        "constructionTime": 10,
         "price": 300,
         "weaponDamage": 20,
         "weaponSpeed": 0,
         "weaponCooldownPeriod": 10,
         "energyGeneratedPerTurn": 0,
-        "destroyMultiplier": 1,
-        "constructionScore": 1
+        "destroyMultiplier": 10,
+        "constructionScore": 20
       },
       "DEFENSE": {
         "health": 20,
-        "constructionTime": 4,
+        "constructionTime": 3,
         "price": 30,
         "weaponDamage": 0,
         "weaponSpeed": 0,
         "weaponCooldownPeriod": 0,
         "energyGeneratedPerTurn": 0,
         "destroyMultiplier": 1,
-        "constructionScore": 1
-      },
-      "ATTACK": {
-        "health": 5,
-        "constructionTime": 2,
-        "price": 30,
-        "weaponDamage": 5,
-        "weaponSpeed": 1,
-        "weaponCooldownPeriod": 3,
-        "energyGeneratedPerTurn": 0,
-        "destroyMultiplier": 1,
-        "constructionScore": 1
+        "constructionScore": 10
       },
       "ENERGY": {
         "health": 5,
-        "constructionTime": 2,
+        "constructionTime": 1,
         "price": 20,
         "weaponDamage": 0,
         "weaponSpeed": 0,
         "weaponCooldownPeriod": 0,
         "energyGeneratedPerTurn": 3,
         "destroyMultiplier": 1,
-        "constructionScore": 1
+        "constructionScore": 3
+      },
+      "ATTACK": {
+        "health": 5,
+        "constructionTime": 1,
+        "price": 30,
+        "weaponDamage": 5,
+        "weaponSpeed": 2,
+        "weaponCooldownPeriod": 3,
+        "energyGeneratedPerTurn": 0,
+        "destroyMultiplier": 1,
+        "constructionScore": 4
       }
     }
   },

--- a/starter-pack/examples/example-textMap.txt
+++ b/starter-pack/examples/example-textMap.txt
@@ -8,10 +8,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ****** BUILDING STATS ******
 type;health;constructionTime;price;weaponDamage;weaponSpeed;weaponCooldownPeriod;energyGeneratedPerTurn;destroyMultiplier;constructionScore
-ATTACK;5;2;30;5;2;3;0;1;15;
-DEFENSE;20;4;30;0;0;0;0;1;10;
-ENERGY;5;2;20;0;0;0;3;1;3;
-TESLA;5;11;300;20;0;10;0;1;1;
+ATTACK;5;1;30;5;2;3;0;1;4;
+DEFENSE;20;3;30;0;0;0;0;1;10;
+ENERGY;5;1;20;0;0;0;3;1;3;
+TESLA;5;10;300;20;0;10;0;10;20;
 *****************************
 
 ---------- PLAYER A ----------
@@ -71,6 +71,7 @@ FORMAT : [x,y] Owner|BuildingType|ConstructionTimeLeft|Health|WeaponCooldownTime
 [11,4] B|ATTACK|0|5|2|5|0
 [12,4] B|ATTACK|0|5|3|5|0
 [13,4] B|ATTACK|1|5|0|5|0
+[3,0] A|TESLA|9|5|0|20|0
 ###############################
 
 ####### MISSILE DATA ########

--- a/starter-pack/game-config.properties
+++ b/starter-pack/game-config.properties
@@ -10,7 +10,7 @@ game.config.energy-score-multiplier = 1
 game.config.deconstruction-refund-amount = 5
 game.config.max-do-nothings = 50
 
-#Basic Wall Config
+#DEFENSE Building Config
 game.config.defense.config.health = 20
 game.config.defense.config.construction-time-left = 3
 game.config.defense.config.price = 30
@@ -23,7 +23,7 @@ game.config.defense.config.construction-score = 10
 game.config.defense.config.energy-produced-per-turn = 0
 game.config.defense.config.max-range = 0
 
-#Basic Turret Config
+#ATTACK Building Config
 game.config.attack.config.health = 5
 game.config.attack.config.construction-time-left = 1
 game.config.attack.config.price = 30
@@ -37,7 +37,7 @@ game.config.attack.config.energy-produced-per-turn = 0
 game.config.attack.config.max-range = 0
 
 
-#Basic Energy Generator Config
+#ENERGY Building Config
 game.config.energy.config.health = 5
 game.config.energy.config.construction-time-left = 1
 game.config.energy.config.price = 20
@@ -50,7 +50,7 @@ game.config.energy.config.construction-score = 3
 game.config.energy.config.energy-produced-per-turn = 3
 game.config.energy.config.max-range = 0
 
-#Tesla Tower Config
+#TESLA Building Config
 game.config.tesla.config.health = 5
 game.config.tesla.config.construction-time-left = 10
 game.config.tesla.config.price = 300


### PR DESCRIPTION
fix #109 
Construction time was catered for with a plus 1 since it ran at the start of round processing, and would be decreased by 1 before the round processing is done.

This did not happen for the renderers though. Now they will show