### PR TITLE
Add program arguments and wire them up for the Haskell runner

### DIFF
--- a/game-runner/src/main/java/za/co/entelect/challenge/botrunners/BotRunner.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/botrunners/BotRunner.java
@@ -5,6 +5,7 @@ import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 import za.co.entelect.challenge.entities.BotMetaData;
+import za.co.entelect.challenge.entities.BotArguments;
 import za.co.entelect.challenge.game.contracts.exceptions.TimeoutException;
 
 import java.io.ByteArrayOutputStream;
@@ -36,6 +37,8 @@ public abstract class BotRunner {
     public String getBotFileName() {
         return botMetaData.getBotFileName();
     }
+
+    public BotArguments getArguments() { return botMetaData.getArguments(); }
 
     protected String RunSimpleCommandLineCommand(String line, int expectedExitValue) throws IOException, TimeoutException {
         CommandLine cmdLine = CommandLine.parse(line);

--- a/game-runner/src/main/java/za/co/entelect/challenge/botrunners/HaskellBotRunner.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/botrunners/HaskellBotRunner.java
@@ -1,6 +1,7 @@
 package za.co.entelect.challenge.botrunners;
 
 import za.co.entelect.challenge.entities.BotMetaData;
+import za.co.entelect.challenge.entities.BotArguments;
 import za.co.entelect.challenge.game.contracts.exceptions.TimeoutException;
 
 import java.io.IOException;
@@ -13,12 +14,20 @@ public class HaskellBotRunner extends BotRunner {
 
     @Override
     protected String runBot() throws IOException, TimeoutException {
+        String runTimeArguments;
+        if (this.getArguments() != null) {
+            int coreCount = this.getArguments().getCoreCount();
+            runTimeArguments = " +RTS -N" + Integer.toString(coreCount) + " -RTS";
+        } else {
+            runTimeArguments = "";
+        }
+
         String line;
 
         if(System.getProperty("os.name").contains("Windows")) {
-            line = "cmd /c \"" + this.getBotFileName() + "\"";
+            line = "cmd /c \"" + this.getBotFileName() + runTimeArguments + "\"";
         } else {
-            line = "\"./" + this.getBotFileName() + "\"";
+            line = "./" + this.getBotFileName() + runTimeArguments;
         }
 
         return RunSimpleCommandLineCommand(line, 0);

--- a/game-runner/src/main/java/za/co/entelect/challenge/entities/BotArguments.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/entities/BotArguments.java
@@ -1,0 +1,16 @@
+package za.co.entelect.challenge.entities;
+
+import com.google.gson.annotations.SerializedName;
+
+public class BotArguments {
+    @SerializedName("coreCount")
+    private int coreCount;
+
+    public BotArguments(int coreCount) {
+        this.coreCount = coreCount;
+    }
+
+    public int getCoreCount() {
+        return this.coreCount;
+    }
+}

--- a/game-runner/src/main/java/za/co/entelect/challenge/entities/BotMetaData.java
+++ b/game-runner/src/main/java/za/co/entelect/challenge/entities/BotMetaData.java
@@ -2,6 +2,7 @@ package za.co.entelect.challenge.entities;
 
 import com.google.gson.annotations.SerializedName;
 import za.co.entelect.challenge.enums.BotLanguage;
+import za.co.entelect.challenge.entities.BotArguments;
 
 import java.nio.file.Paths;
 
@@ -19,6 +20,8 @@ public class BotMetaData {
     private String botLocation;
     @SerializedName("botFileName")
     private String botFileName;
+    @SerializedName("arguments")
+    private BotArguments arguments;
 
     public BotMetaData(BotLanguage language, String botLocation, String botFileName){
         this.botLanguage = language;
@@ -56,5 +59,9 @@ public class BotMetaData {
 
     public String getBotDirectory() {
         return Paths.get(getBotLocation()).toAbsolutePath().normalize().toString();
+    }
+
+    public BotArguments getArguments() {
+        return this.arguments;
     }
 }

--- a/starter-bots/haskell/README.md
+++ b/starter-bots/haskell/README.md
@@ -24,3 +24,39 @@ Haskell creates native binaries so you can simply run:
 ```
 
 from the command line to invoke the bot program.
+
+## Running the Bot with Multiple Threads
+In order to run the Haskell bot with multiple threads (and possibly
+cores) you need to change the bot configuration to inform the runner
+to supply the appropriate runtime arguments.  The following is an
+example "bot.json" for launching the bot with 2 threads:
+
+```
+{
+    "author": "John Doe",
+    "email": "john.doe@email.com",
+    "nickName": "a-bot",
+    "botLocation": "/bin",
+    "botFileName": "EntelectChallenge2018-exe",
+    "botLanguage": "haskell",
+    "arguments": {
+        "coreCount": 2
+    }
+}
+```
+
+You should also ensure that the executable is built with the
+"-rtsopts" and "-threaded" compile time flags.  These are supplied
+under the "executables" section in "package.yaml".  e.g.
+
+```
+executables:
+  EntelectChallenge2018-exe:
+    main:                Main.hs
+    source-dirs:         app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    dependencies:
+    - EntelectChallenge2018
+```

--- a/starter-bots/haskell/bot.json
+++ b/starter-bots/haskell/bot.json
@@ -4,5 +4,8 @@
 	"nickName": "Bill",
 	"botLocation": "/bin",
 	"botFileName": "EntelectChallenge2018-exe",
-	"botLanguage": "haskell"
+	"botLanguage": "haskell",
+    	"arguments": {
+        	"coreCount": 2
+    	}
 }


### PR DESCRIPTION
This enables Haskell bots to use multiple cores when asked for in the bot.json.

Background:
Haskell is a bit weird in the way that you specify how many cores a program should run with.  First the program must have been compiled with two special flags (threaded and rtsopts).  Next you must run the program with the '-N' runtime flag; e.g.

`./MyBot +RTS -N4 -RTS`

To tell it to use 4 cores.

In this PR I've generalised this a bit and allowed the dev to specify any parameters to pass to the bot between the RTS's in the field 'arguments' in bot.json.